### PR TITLE
make CMD in Dockerfile valid Json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN go build -a -installsuffix cgo -o /bin/app .
 FROM scratch
 ADD https://curl.haxx.se/ca/cacert.pem /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /bin/app /bin/app
-CMD ['/bin/app']
+CMD ["/bin/app"]


### PR DESCRIPTION
This fixes #10 

minor change making the CMD valid json and thus preventing docker from interpreting it as `sh -c "['/bin/app']"`