### PR TITLE
Adding proxy to Transport

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,6 +142,8 @@ func authenticate(role, jwt string) (string, string, error) {
 		Transport: transport,
 	}
 
+	transport.Proxy = http.ProxyFromEnvironment
+
 	addr := vaultAddr + "/v1/auth/" + vaultK8SMountPath + "/login"
 	body := fmt.Sprintf(`{"role": "%s", "jwt": "%s"}`, role, jwt)
 


### PR DESCRIPTION
I just had issues to connect to vault behind a proxy and added the environments proxy to the constructed transport object.